### PR TITLE
cargo: drop publish-lockfile nightly feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["publish-lockfile"]
-
 [package]
 name = "raider-server"
 version = "1.1.1"
@@ -12,7 +10,6 @@ keywords = ["affiliates", "dashboard", "sales", "tracker"]
 categories = ["web-programming"]
 authors = ["Valerian Saliou <valerian@valeriansaliou.name>"]
 exclude = ["dev/*"]
-publish-lockfile = true
 
 [badges]
 travis-ci = { repository = "valeriansaliou/raider", branch = "master" }


### PR DESCRIPTION
The publishing of lockfile has been part of newer versions of cargo
for some time now.

    warning: The `publish-lockfile` feature is deprecated and currently
    has no effect. It may be removed in a future version.